### PR TITLE
Disabled cache discovery

### DIFF
--- a/fs/googledrivefs/googledrivefs.py
+++ b/fs/googledrivefs/googledrivefs.py
@@ -110,7 +110,7 @@ class GoogleDriveFS(FS):
 	def __init__(self, credentials):
 		super().__init__()
 
-		self.drive = build("drive", "v3", credentials=credentials)
+		self.drive = build("drive", "v3", credentials=credentials, cache_discovery=False)
 
 		_meta = self._meta = {
 			"case_insensitive": True, # it will even let you have 2 identical filenames in the same directory! But the search is case-insensitive


### PR DESCRIPTION
This small change will silence noisy "file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth" in logs.